### PR TITLE
ehlo/helo after starttls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- do `EHLO` or `HELO` after `STARTTLS` https://github.com/ruslandoga/mua/pull/7
+
 ## v0.1.3 (2023-07-14)
 
 - add `Mua.TransportError` like in [Mint](https://github.com/elixir-mint/mint/blob/main/lib/mint/transport_error.ex) https://github.com/ruslandoga/mua/pull/6

--- a/lib/mua.ex
+++ b/lib/mua.ex
@@ -145,6 +145,7 @@ defmodule Mua do
       try do
         with {:ok, extensions} <- ehlo_or_helo(socket, fqdn, timeout),
              {:ok, socket} <- maybe_starttls(proto, extensions, socket, host, sock_opts, timeout),
+             {:ok, extensions} <- ehlo_or_helo(socket, fqdn, timeout),
              :ok <- maybe_auth(extensions, socket, auth_creds, timeout),
              :ok <- mail_from(socket, sender, timeout),
              :ok <- many_rcpt_to(recipients, socket, timeout),


### PR DESCRIPTION
for auth extension to show up and some hosts seem to require it (e.g. ya.ru)