### PR TITLE
remove guess_sender_hostname/0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- remove unused `guess_sender_hostname/0` https://github.com/ruslandoga/mua/pull/48
+
 ## v0.2.2 (2024-06-10)
 
 - default to `:public_key.cacerts_get/0` instead of `CAStore`

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
 - tests (mailpit starttls, etc.)
-- remove guess_sender_hostname/0
 - configure if tls is required or not
 - telemetry (bounces, etc.)

--- a/lib/mua.ex
+++ b/lib/mua.ex
@@ -22,22 +22,6 @@ defmodule Mua do
 
   @default_timeout :timer.seconds(30)
 
-  require Record
-  Record.defrecordp(:hostent, Record.extract(:hostent, from_lib: "kernel/include/inet.hrl"))
-
-  @doc """
-  Utility function to guess the local hostname to use for HELO/EHLO.
-
-      {:ok, "mac3"} = guess_sender_hostname()
-
-  """
-  @spec guess_sender_hostname :: {:ok, String.t()} | {:error, :inet.posix()}
-  def guess_sender_hostname do
-    with {:ok, hostname} <- :inet.gethostname(),
-         {:ok, hostent(h_name: hostname)} <- :inet.gethostbyname(hostname),
-         do: {:ok, List.to_string(hostname)}
-  end
-
   @doc """
   Utility function to lookup MX servers for a domain.
 

--- a/test/mua_test.exs
+++ b/test/mua_test.exs
@@ -59,13 +59,6 @@ defmodule MuaTest do
     end
   end
 
-  test "guess_sender_hostname/0" do
-    {os_hostname, 0} = System.cmd("hostname", ["-f"])
-    os_hostname = String.trim(os_hostname)
-    assert {:ok, guessed_hostname} = Mua.guess_sender_hostname()
-    assert guessed_hostname in [os_hostname, String.trim_trailing(os_hostname, ".local")]
-  end
-
   test "transport_error message" do
     assert Exception.message(Mua.TransportError.exception(reason: :timeout)) == "timeout"
     assert Exception.message(Mua.TransportError.exception(reason: :closed)) == "socket closed"


### PR DESCRIPTION
This helper isn't used since we use hostname from the MAIL FROM address.

For example, here we would send `EHLO github.com`

```elixir
Mua.easy_send(
  _host = "localhost",
  _mail_from = "mua@github.com",
  _rcpt_to = ["receiver1@mailpit.example", "receiver2@mailpit.example"]
)
```